### PR TITLE
Fix loading ENV variable from .env file in deployment script

### DIFF
--- a/scripts/start_application.sh
+++ b/scripts/start_application.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 set -e
 
-# Load environment variables from .env file if it exists
-if [ -f ".env" ]; then
-  export $(grep -v '^#' .env | xargs)
-fi
 
 cd /home/epic-user/realtime-backend/alertora || {
   echo "Directory not found!"
   exit 1
 }
+
+if [ -f ".env" ]; then
+  export ENV=$(grep '^ENV=' .env | cut -d '=' -f2- | tr -d '"')
+fi
+
 
 # Determine environment and copy appropriate nginx config
 if [[ "$ENV" == "staging" ]]; then


### PR DESCRIPTION
- The script now explicitly extracts only the ENV variable from the .env file instead of exporting all variables, avoiding issues with improperly formatted environment variables.

- Ensures the cd into the application directory happens before attempting to read the .env file so the file path resolves correctly.